### PR TITLE
change the installation of psycopg2. Because use pip install psycopg2…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django==2.1.7
-psycopg2==2.7.7
+psycopg2-binary==2.7.7
 pytz==2018.9


### PR DESCRIPTION
… is now deprecated and should be replaced by psycopg2-binary